### PR TITLE
Fix: add space between URIs for multi unpack sources

### DIFF
--- a/classes/xt_quirks.bbclass
+++ b/classes/xt_quirks.bbclass
@@ -38,7 +38,7 @@ python do_unpack_xt_extras() {
     urls = (d.getVar("XT_QUIRK_UNPACK_SRC_URI") or "").split()
     for url in urls:
         type, _, location, _, _, _ = bb.fetch.decodeurl(url)
-        item = check_url_or_pack(url, type, location, d)
+        item = check_url_or_pack(url, type, location, d) + " "
         d.appendVar("SRC_URI", item or "")
 
     # now call real unpacker to do the rest


### PR DESCRIPTION
While preparing SRC_URI for oroginal unpacker from
XT_QUIRK_UNPACK a space was not added between URIs,
makeing resuilting SRC_URI not a list of values,
but a single combined one.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>