### PR TITLE
Allow selecting R-Car EVA proprietary dir

### DIFF
--- a/inc/xt_rcar.inc
+++ b/inc/xt_rcar.inc
@@ -1,5 +1,11 @@
+EXPANDED_XT_RCAR_EVAPROPRIETARY_DIR = "${@d.getVar('XT_RCAR_EVAPROPRIETARY_DIR') or '""'}"
+
 rcar_unpack_evaproprietary() {
     export PKGS_DIR="${S}/proprietary/rcar/m3_h3_gfx"
+    if [ -n "${EXPANDED_XT_RCAR_EVAPROPRIETARY_DIR}" ] ; then
+        install -d ${PKGS_DIR}
+        cp -rf ${XT_RCAR_EVAPROPRIETARY_DIR}/* ${PKGS_DIR}
+    fi
     cd ${PKGS_DIR}
     unzip -oq R-Car_Gen3_Series_Evaluation_Software_Package_for_Linux-*.zip
     unzip -oq R-Car_Gen3_Series_Evaluation_Software_Package_of_Linux_Drivers-*.zip


### PR DESCRIPTION
Allow selecting R-Car EVA proprietary archives
directory via setting XT_RCAR_EVAPROPRIETARY_DIR
variable.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>