### PR TITLE
Extend XT_QUIRK_PATCH to allow remote patches

### DIFF
--- a/classes/xt_quirks.bbclass
+++ b/classes/xt_quirks.bbclass
@@ -55,4 +55,10 @@ python do_patch_prepend() {
     d.appendVar("SRC_URI", "\n")
     urls = (d.getVar("XT_QUIRK_PATCH_SRC_URI") or "").split()
     d.appendVar("SRC_URI", d.getVar("XT_QUIRK_PATCH_SRC_URI") or "")
+    try:
+        fetcher = bb.fetch2.Fetch(urls, d)
+        fetcher.download()
+    except bb.fetch2.BBFetchException as e:
+        bb.fatal(str(e))
+
 }


### PR DESCRIPTION
Extend existing functionality by allowing patches
to be downloaded, e.g. when one wants to fetch a
patch from Github's pullrequest, e.g. from link
like http://github.com/xen-troops/meta-demo/pull/3.patch.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>