### PR TITLE
Fix issue #8: add libgbm as dependency to kmscube

### DIFF
--- a/machine/meta-rcar-gen3/recipes-graphics/kmscube/kmscube_git.bb
+++ b/machine/meta-rcar-gen3/recipes-graphics/kmscube/kmscube_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Demo application to showcase 3D graphics using kms and gbm"
 HOMEPAGE = "https://cgit.freedesktop.org/mesa/kmscube/"
 LICENSE = "MIT"
 SECTION = "graphics"
-DEPENDS = "virtual/libgles2 virtual/egl libdrm gstreamer1.0 gstreamer1.0-plugins-base"
+DEPENDS = "virtual/libgles2 virtual/egl libdrm libgbm gstreamer1.0 gstreamer1.0-plugins-base"
 
 LIC_FILES_CHKSUM = "file://kmscube.c;beginline=1;endline=23;md5=8b309d4ee67b7315ff7381270dd631fb"
 


### PR DESCRIPTION
This fixes https://github.com/xen-troops/meta-xt-images/issues/8

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>