### PR TITLE
Fix issue #13: xentop is not installed after XEN build

### DIFF
--- a/machine/meta-rcar-gen3/recipes-extended/xen/xen_git.bbappend
+++ b/machine/meta-rcar-gen3/recipes-extended/xen/xen_git.bbappend
@@ -69,3 +69,7 @@ RDEPENDS_${PN}-efi = " \
     bash \
     python \
     "
+
+RDEPENDS_${PN}-base += " \
+    ${PN}-xenstat \
+    "


### PR DESCRIPTION
Signed-off-by: Iurii Artemenko <Iurii_Artemenko@epam.com>