### PR TITLE
Add environment variable to specify LLVM build directory

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-core/meta/meta-environment.bbappend
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-core/meta/meta-environment.bbappend
@@ -1,0 +1,5 @@
+# Add environment variable to specify LLVM build directory
+toolchain_shared_env_script_prepend () {
+    echo 'export PVRLLVM_BUILD_DIR="${SDKTARGETSYSROOT}${libdir}/llvm_build_dir"' >> $script
+}
+


### PR DESCRIPTION
Environment setup script have to provide it together with
other SDK environment variables.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>