### PR TITLE
doma: Use OUT_DIR_COMMON_BASE to configure Android

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
+++ b/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
@@ -30,6 +30,8 @@ ANDROID_JACK_MEM_SIZE_GB = "4"
 
 JAVA_HOME = "${STAGING_LIBDIR_JVM_NATIVE}/${JDK_VER}"
 
+ANDROID_OUT_DIR_COMMON_BASE = ""
+
 do_configure() {
 }
 
@@ -42,7 +44,7 @@ do_compile() {
     # run Android build in sane environment
     env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" USER="$USER" \
            PATH="${JAVA_HOME}/bin:${S}/${ANDROID_CCACHE_BIN_DIR}:$PATH" \
-           JAVA_HOME="${JAVA_HOME}" \
+           JAVA_HOME="${JAVA_HOME}" OUT_DIR_COMMON_BASE="${ANDROID_OUT_DIR_COMMON_BASE}" \
            USE_CCACHE="1" CCACHE_DIR="${ANDROID_CCACHE_DIR}" \
            bash -c "${ANDROID_CCACHE_BIN_DIR}/ccache -M ${ANDROID_CCACHE_SIZE_GB}G && \
                     source build/envsetup.sh && \


### PR DESCRIPTION
Use OUT_DIR_COMMON_BASE to specify where Android will put
all its ouput, so it can be re-used during incremental builds
and not gets cleaned out.