### PR TITLE
doma: Add bc as native dependency to the build

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
+++ b/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
@@ -14,7 +14,7 @@ inherit java
 
 JDK_VER = "openjdk-8-native"
 
-DEPENDS += "${JDK_VER} lz4-native"
+DEPENDS += "${JDK_VER} lz4-native bc-native"
 
 ANDROID_PRODUCT ?= "aosp_arm64"
 ANDROID_VARIANT ?= "eng"


### PR DESCRIPTION
Android's kernel needs bc-native, so add it.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>