### PR TITLE
doma: Do not try to populate SDK

### DIFF
--- a/recipes-domu/domu-image-android/domu-image-android.bb
+++ b/recipes-domu/domu-image-android/domu-image-android.bb
@@ -54,3 +54,7 @@ python do_configure_append() {
     bb.build.exec_func("update_local_conf", d)
 }
 
+# we do not have an SDK to populate
+do_populate_sdk() {
+}
+


### PR DESCRIPTION
As Android is built as a recipe, not an image it doesn't
provide any Yocto SDK.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>