### PR TITLE
doma: Set ccache's base_dir for Android build

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
+++ b/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
@@ -50,7 +50,7 @@ do_compile() {
     env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" USER="$USER" \
            PATH="${JAVA_HOME}/bin:${S}/${ANDROID_CCACHE_BIN_DIR}:$PATH" \
            JAVA_HOME="${JAVA_HOME}" OUT_DIR_COMMON_BASE="${ANDROID_OUT_DIR_COMMON_BASE}" \
-           USE_CCACHE="1" CCACHE_DIR="${ANDROID_CCACHE_DIR}" \
+           USE_CCACHE="1" CCACHE_DIR="${ANDROID_CCACHE_DIR}" CCACHE_BASEDIR="${S}" \
            bash -c "${ANDROID_CCACHE_BIN_DIR}/ccache -M ${ANDROID_CCACHE_SIZE_GB}G && \
                     source build/envsetup.sh && \
                     lunch ${ANDROID_PRODUCT}-${ANDROID_VARIANT} && \


### PR DESCRIPTION
According to https://ccache.samba.org/manual.html#_compiling_in_different_directories
"...if you compile the same code in different locations, you can’t
share compilation results between the different build directories
since you get cache misses because of the absolute build directory
paths that are part of the hash. To mitigate this problem, you can
specify a “base directory” in the configuration setting base_dir to
an absolute path to the directory. ccache will then rewrite absolute
paths that are under the base directory (i.e., paths that have the
base directory as a prefix) to relative paths when constructing the hash.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>