### PR TITLE
doma: Fix repo sync directory on unpack

### DIFF
--- a/recipes-domu/domu-image-android/files/0001-fetch2-repo-Always-check-if-branch-is-correct.patch
+++ b/recipes-domu/domu-image-android/files/0001-fetch2-repo-Always-check-if-branch-is-correct.patch
@@ -1,4 +1,4 @@
-From 490dbf31827d35a6bf615aed36b967eee70ebe4b Mon Sep 17 00:00:00 2001
+From b2602c3f406158879330e7cab52b3cb6907e1034 Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Tue, 24 Oct 2017 10:04:03 +0300
 Subject: [PATCH 1/3] fetch2/repo: Always check if branch is correct
@@ -15,7 +15,7 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 1be91cc698e3..6b2efa2b91f8 100644
+index 1be91cc..6b2efa2 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
 @@ -70,9 +70,8 @@ class Repo(FetchMethod):

--- a/recipes-domu/domu-image-android/files/0002-fetch2-repo-Make-fetcher-always-sync-on-unpack.patch
+++ b/recipes-domu/domu-image-android/files/0002-fetch2-repo-Make-fetcher-always-sync-on-unpack.patch
@@ -1,4 +1,4 @@
-From a6720d0014a89b430adc30672d6efd32b532cf44 Mon Sep 17 00:00:00 2001
+From 87abc0b6214c188883ecb51a0e89a154278906e9 Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Thu, 26 Oct 2017 17:16:49 +0300
 Subject: [PATCH 2/3] fetch2/repo: Make fetcher always sync on unpack
@@ -15,7 +15,7 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  1 file changed, 13 insertions(+), 9 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 6b2efa2b91f8..7035926591e3 100644
+index 6b2efa2..d51d1eb 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
 @@ -51,6 +51,10 @@ class Repo(FetchMethod):
@@ -65,7 +65,7 @@ index 6b2efa2b91f8..7035926591e3 100644
 +    def unpack(self, ud, destdir, d):
 +        FetchMethod.unpack(self, ud, destdir, d)
 +        bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
-+        runfetchcmd("repo sync", d, workdir=ud.repodir)
++        runfetchcmd("repo sync", d, workdir=destdir)
  
      def supports_srcrev(self):
          return False

--- a/recipes-domu/domu-image-android/files/0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch
+++ b/recipes-domu/domu-image-android/files/0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch
@@ -1,4 +1,4 @@
-From 6b7c997d383b74219e3e65cbac4d9c2cb4af3209 Mon Sep 17 00:00:00 2001
+From cfc5a5144100d24ae342694412b0a4097ad64ff3 Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Tue, 24 Oct 2017 10:14:14 +0300
 Subject: [PATCH 3/3] fetch2/repo: Use multiple jobs to fetch and sync
@@ -16,19 +16,19 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 7035926591e3..904520477ec2 100644
+index d51d1eb..0ed0f92 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
 @@ -56,6 +56,13 @@ class Repo(FetchMethod):
          ud.codir = os.path.join(repodir, gitsrcname, ud.manifest)
          ud.repodir = os.path.join(ud.codir, "repo")
  
-+    def sync(self, ud, d):
++    def sync(self, destdir, d):
 +        # repo can separate the "network" sync (the git fetch part, network bound)
 +        # from the "local" sync (the git rebase part, compute & i/o bound).
 +        num_jobs = d.getVar("BB_NUMBER_THREADS", True) or "1"
-+        runfetchcmd("repo sync -c -n -j%s" % num_jobs, d, workdir=ud.repodir)
-+        runfetchcmd("repo sync -c -l -j%s" % num_jobs, d, workdir=ud.repodir)
++        runfetchcmd("repo sync -c -n -j%s" % num_jobs, d, workdir=destdir)
++        runfetchcmd("repo sync -c -l -j%s" % num_jobs, d, workdir=destdir)
 +
      def download(self, ud, d):
          """Fetch url"""
@@ -38,7 +38,7 @@ index 7035926591e3..904520477ec2 100644
  
          bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
 -        runfetchcmd("repo sync", d, workdir=ud.repodir)
-+        self.sync(ud, d)
++        self.sync(ud.repodir, d)
  
          scmdata = ud.parm.get("scmdata", "")
          if scmdata == "keep":
@@ -46,8 +46,8 @@ index 7035926591e3..904520477ec2 100644
      def unpack(self, ud, destdir, d):
          FetchMethod.unpack(self, ud, destdir, d)
          bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
--        runfetchcmd("repo sync", d, workdir=ud.repodir)
-+        self.sync(ud, d)
+-        runfetchcmd("repo sync", d, workdir=destdir)
++        self.sync(os.path.join(destdir, "repo"), d)
  
      def supports_srcrev(self):
          return False


### PR DESCRIPTION
While doing repo sync it needs to be done in the directory
where archiver on do_unpack works, not where repo init happens.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>