### PR TITLE
Do not use -jMAX for gles-user-module

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
@@ -42,6 +42,9 @@ RPROVIDES_${PN} += " \
     libopencl \
 "
 
+# FIXME: because of LLVM this recipe behaves much better if not run with -jMAX
+PARALLEL_MAKE = "-j ${@oe.utils.cpu_count() - 1}"
+
 EXTRA_OEMAKE += "CROSS_COMPILE=${TARGET_PREFIX}"
 EXTRA_OEMAKE += "PVR_BUILD_DIR=${PVRUM_BUILD_DIR}"
 EXTRA_OEMAKE += "DISCIMAGE=${PVRUM_DISCIMAGE}"


### PR DESCRIPTION
Because of LLVM gles-user-modulerecipe behaves much better
if not run with -jMAX.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>