### PR TITLE
Suppress warnings on runtime dependency

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-core/llvm/llvmpvr_3.7.0.bb
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-core/llvm/llvmpvr_3.7.0.bb
@@ -112,5 +112,5 @@ do_install() {
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-INSANE_SKIP_${PN} += "ldflags split-strip arch staticdev"
+INSANE_SKIP_${PN} += "ldflags split-strip arch staticdev file-rdeps"
 FILES_${PN} += "${libdir}/llvm_build_dir/"


### PR DESCRIPTION
A shell script might start with the line #!/bin/bash.
This line would translate to a file dependency on /bin/bash.
Only RPM directly handles file-level dependencies.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>