### PR TITLE
domu/android: Make pack/unpack multithreaded

### DIFF
--- a/recipes-domu/domu-image-android/domu-image-android.bb
+++ b/recipes-domu/domu-image-android/domu-image-android.bb
@@ -38,6 +38,7 @@ SRC_URI_append = " \
     file://0001-fetch2-repo-Always-check-if-branch-is-correct.patch;patchdir=poky \
     file://0002-fetch2-repo-Make-fetcher-always-sync-on-unpack.patch;patchdir=poky \
     file://0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch;patchdir=poky \
+    file://0004-Make-pack-unpack-multithreaded.patch;patchdir=poky \
 "
 
 update_local_conf() {

--- a/recipes-domu/domu-image-android/files/0001-fetch2-repo-Always-check-if-branch-is-correct.patch
+++ b/recipes-domu/domu-image-android/files/0001-fetch2-repo-Always-check-if-branch-is-correct.patch
@@ -1,7 +1,7 @@
-From b2602c3f406158879330e7cab52b3cb6907e1034 Mon Sep 17 00:00:00 2001
+From a733c75f3a0918d85e433e4fc567cb3b9949858b Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Tue, 24 Oct 2017 10:04:03 +0300
-Subject: [PATCH 1/3] fetch2/repo: Always check if branch is correct
+Subject: [PATCH 1/4] fetch2/repo: Always check if branch is correct
 
 Current implementation doesn't pay attention if
 the same repository is used for manifest, but different
@@ -15,7 +15,7 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 1be91cc..6b2efa2 100644
+index 1be91cc698e3..6b2efa2b91f8 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
 @@ -70,9 +70,8 @@ class Repo(FetchMethod):

--- a/recipes-domu/domu-image-android/files/0002-fetch2-repo-Make-fetcher-always-sync-on-unpack.patch
+++ b/recipes-domu/domu-image-android/files/0002-fetch2-repo-Make-fetcher-always-sync-on-unpack.patch
@@ -1,7 +1,7 @@
-From 87abc0b6214c188883ecb51a0e89a154278906e9 Mon Sep 17 00:00:00 2001
+From d8cc9c16df233abfc39efbc04e37a795134588bd Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Thu, 26 Oct 2017 17:16:49 +0300
-Subject: [PATCH 2/3] fetch2/repo: Make fetcher always sync on unpack
+Subject: [PATCH 2/4] fetch2/repo: Make fetcher always sync on unpack
 
 Currently if repo has fetched the repository and
 cached it to a tar file it never runs repo sync again,
@@ -15,7 +15,7 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  1 file changed, 13 insertions(+), 9 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 6b2efa2..d51d1eb 100644
+index 6b2efa2b91f8..d51d1ebf7a07 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
 @@ -51,6 +51,10 @@ class Repo(FetchMethod):

--- a/recipes-domu/domu-image-android/files/0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch
+++ b/recipes-domu/domu-image-android/files/0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch
@@ -1,7 +1,7 @@
-From cfc5a5144100d24ae342694412b0a4097ad64ff3 Mon Sep 17 00:00:00 2001
+From 199868288780e6eaa0a7632d2de80e2c84f9d73d Mon Sep 17 00:00:00 2001
 From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 Date: Tue, 24 Oct 2017 10:14:14 +0300
-Subject: [PATCH 3/3] fetch2/repo: Use multiple jobs to fetch and sync
+Subject: [PATCH 3/4] fetch2/repo: Use multiple jobs to fetch and sync
 
 Google repo supports "--jobs" parameter, so one can
 speed up the process of fetching and syncing. According to
@@ -16,7 +16,7 @@ Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index d51d1eb..0ed0f92 100644
+index d51d1ebf7a07..0ed0f923f6a4 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
 @@ -56,6 +56,13 @@ class Repo(FetchMethod):

--- a/recipes-domu/domu-image-android/files/0004-Make-pack-unpack-multithreaded.patch
+++ b/recipes-domu/domu-image-android/files/0004-Make-pack-unpack-multithreaded.patch
@@ -1,0 +1,44 @@
+From 6526322512920e9b020fffe948100d024ee19774 Mon Sep 17 00:00:00 2001
+From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
+Date: Fri, 29 Dec 2017 17:26:49 +0200
+Subject: [PATCH 4/4] Make pack/unpack multithreaded
+
+Use pigz/unpigz to make fetcher's pack/unpack tar
+run in parallel.
+
+Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
+Signed-off-by: Artem Mygaiev <artem_mygaiev@epam.com>
+---
+ bitbake/lib/bb/fetch2/__init__.py | 2 +-
+ bitbake/lib/bb/fetch2/repo.py     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bitbake/lib/bb/fetch2/__init__.py b/bitbake/lib/bb/fetch2/__init__.py
+index b853da30bdbf..2a0f875dd394 100644
+--- a/bitbake/lib/bb/fetch2/__init__.py
++++ b/bitbake/lib/bb/fetch2/__init__.py
+@@ -1398,7 +1398,7 @@ class FetchMethod(object):
+ 
+         if unpack:
+             if file.endswith('.tar'):
+-                cmd = 'tar x --no-same-owner -f %s' % file
++                cmd = 'unpigz < %s | tar x --no-same-owner' % file
+             elif file.endswith('.tgz') or file.endswith('.tar.gz') or file.endswith('.tar.Z'):
+                 cmd = 'tar xz --no-same-owner -f %s' % file
+             elif file.endswith('.tbz') or file.endswith('.tbz2') or file.endswith('.tar.bz2'):
+diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
+index 0ed0f923f6a4..adf437a24e32 100644
+--- a/bitbake/lib/bb/fetch2/repo.py
++++ b/bitbake/lib/bb/fetch2/repo.py
+@@ -89,7 +89,7 @@ class Repo(FetchMethod):
+             tar_flags = "--exclude='.repo' --exclude='.git'"
+ 
+         # Create a cache
+-        runfetchcmd("tar %s -czf %s %s" % (tar_flags, ud.localpath, os.path.join(".", "*") ), d, workdir=ud.codir)
++        runfetchcmd("tar %s -cf - %s | pigz > %s" % (tar_flags, os.path.join(".", "*"), ud.localpath), d, workdir=ud.codir)
+ 
+     def unpack(self, ud, destdir, d):
+         FetchMethod.unpack(self, ud, destdir, d)
+-- 
+2.7.4
+


### PR DESCRIPTION
Use pigz/unpigz to make fetcher's pack/unpack tar
run in parallel.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Artem Mygaiev <artem_mygaiev@epam.com>