### PR TITLE
rescue: Initial version of the rescue disk

### DIFF
--- a/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bb
+++ b/recipes-dom0/dom0-image-rescue-initramfs/dom0-image-rescue-initramfs.bb
@@ -1,0 +1,49 @@
+SUMMARY = "Minimalistic initrafs image for system rescue"
+
+LICENSE = "MIT"
+
+inherit build_yocto
+inherit xt_quirks
+
+S = "${WORKDIR}/repo"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/../../machine:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/../../recipes-domx:"
+
+###############################################################################
+# extra layers and files to be put after Yocto's do_unpack into inner builder
+###############################################################################
+# these will be populated into the inner build system on do_unpack_xt_extras
+XT_QUIRK_UNPACK_SRC_URI += " \
+    file://meta-xt-images-generic-armv8;subdir=repo \
+    file://meta-xt-images-extra;subdir=repo \
+    file://meta-xt-images-domx;subdir=repo \
+"
+
+# these layers will be added to bblayers.conf on do_configure
+XT_QUIRK_BB_ADD_LAYER += " \
+    meta-xt-images-generic-armv8 \
+    meta-xt-images-extra \
+    meta-xt-images-domx \
+"
+
+################################################################################
+# set to AUTOREV so we can override this while reconstructing this build with
+# specific commit ID
+################################################################################
+SRCREV = "${AUTOREV}"
+
+configure_versions_base() {
+    local local_conf="${S}/build/conf/local.conf"
+
+    cd ${S}
+    # override what xt-distro wants as machine as we don't depend on HW
+    base_update_conf_value ${local_conf} MACHINE "generic-armv8-xt"
+    base_update_conf_value ${local_conf} "PREFERRED_PROVIDER_virtual/kernel" "linux-generic-armv8"
+}
+
+python do_configure_append() {
+    bb.build.exec_func("configure_versions_base", d)
+}
+

--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-images-extra/conf/layer.conf
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-images-extra/conf/layer.conf
@@ -1,0 +1,10 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH =. "${LAYERDIR}:"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-xt-prod-extra"
+BBFILE_PATTERN_meta-xt-prod-extra := "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-xt-prod-extra = "6"

--- a/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-images-extra/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-dom0/dom0-image-rescue-initramfs/files/meta-xt-images-extra/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,1 @@
+hostname .= "-rescue"


### PR DESCRIPTION
Add ability to build an initramfs based image
suitable for booting on Salvator-X M3/H3 with full
hardware support and required set of maintenance utilities
such as file utilities, package management (dpkg, rpm, opkg)
suitable for system recovery and tuning.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>