### PR TITLE
domx: Fix bzr recipe

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-devtools/bazaar/bzr_2.7.0.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-devtools/bazaar/bzr_2.7.0.bb
@@ -10,10 +10,15 @@ SRC_URI[sha256sum] = "0d451227b705a0dd21d8408353fe7e44d3a5069e6c4c26e5f146f1314b
 DEPENDS = "python-native"
 PROVIDES += "bzr-native"
 
-inherit native pythonnative
+inherit native pythonnative distutils
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
+
+export BUILD_SYS
+export HOST_SYS
+export STAGING_LIBDIR
+export STAGING_INCDIR
 
 do_install () {
     python setup.py install


### PR DESCRIPTION
On systems other than AGL bzr fails with the following error:

|     PREFIX = os.path.normpath(sys.prefix).replace( os.getenv("BUILD_SYS"), os.getenv("HOST_SYS") )
| TypeError: expected a string or other character buffer object

Fix this byt exporting required envirnoment variables and
inheriting distutils explicitly.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>