### PR TITLE
Install only existing header files

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-module-egl-headers.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-module-egl-headers.inc
@@ -17,8 +17,10 @@ do_configure() {
 
 do_install() {
     # Install header files
-    install -d ${D}/${includedir}/CL
-    install -m 644 ${S}/include/khronos/CL/*.h ${D}/${includedir}/CL/
+    if [ -d ${S}/include/khronos/CL ]; then
+        install -d ${D}/${includedir}/CL
+        install -m 644 ${S}/include/khronos/CL/*.h ${D}/${includedir}/CL/
+    fi
     install -d ${D}/${includedir}/EGL
     install -m 644 ${S}/include/khronos/EGL/*.h ${D}/${includedir}/EGL/
     install -d ${D}/${includedir}/GLES2


### PR DESCRIPTION
It is possible DDK does not support OpenCL so we have to check
for existence of header files before installing them.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>