### PR TITLE
domx:xen: Adopt changes in XEN packages since version 4.10.0

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen_git.bbappend
@@ -16,6 +16,18 @@ RDEPENDS_${PN}-base += "\
     ${PN}-livepatch \
     "
 
+RDEPENDS_${PN}-base_remove += " \
+    ${PN}-blktap \
+    ${PN}-libblktapctl \
+    ${PN}-libvhd \
+    "
+
+RRECOMMENDS_${PN}-base += " \
+    ${PN}-blktap \
+    ${PN}-libblktapctl \
+    ${PN}-libvhd \
+    "
+
 FILES_${PN}-hypervisor += "\
     /usr/lib/debug/xen-syms-* \
     "
@@ -50,10 +62,18 @@ FILES_${PN}-pkgconfig = "\
     ${datadir}/pkgconfig \
     "
 
+FILES_${PN}-libxentoolcore = "${libdir}/libxentoolcore.so.*"
+FILES_${PN}-libxentoolcore-dev = " \
+    ${libdir}/libxentoolcore.so \
+    ${datadir}/pkgconfig/xentoolcore.pc \
+    "
+
 PACKAGES_append = "\
     ${PN}-libxendevicemodel \
     ${PN}-libxendevicemodel-dev \
     ${PN}-pkgconfig \
+    ${PN}-libxentoolcore \
+    ${PN}-libxentoolcore-dev \
     "
 
 SYSTEMD_SERVICE_${PN}-xencommons += " \
@@ -68,4 +88,8 @@ SYSTEMD_SERVICE_${PN}-xencommons_remove += " \
 RDEPENDS_${PN}-efi = " \
     bash \
     python \
+    "
+
+FILES_${PN}-misc_append = "\
+    ${sbindir}/xen-diag \
     "


### PR DESCRIPTION
Changes are taken from:

https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization/commit/?id=8cf0a585e04482627c22a70585f64b183725c370
https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization/commit/?id=c545ee541bb510b2516782ae3b8afb626c906462

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>

This is needed to switch to XEN 4.10.0 in products.