### PR TITLE
Add additional machine overrides to tell Salvator H3 SoC versions

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-4x2g-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-4x2g-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # H3 u-boot configure
 UBOOT_MACHINE = "r8a7795_salvator-x_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar"
+MACHINEOVERRIDES .= ":salvator:rcar:r8a7795-es3"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # H3 u-boot configure
 UBOOT_MACHINE = "r8a7795_salvator-x_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar"
+MACHINEOVERRIDES .= ":salvator:rcar:r8a7795-es2"


### PR DESCRIPTION
There are two versions of r8a7795 SoC available at the moment: v2.0
and v3.0. Add additional machine overrides to tell exact Salvator
H3 SoC versions, so this can be used in recipes.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>