### PR TITLE
domx: Fix weak setting for SRC_URI for kernel-module-gles

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles_1.9.bb
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles_1.9.bb
@@ -16,7 +16,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 PVRKM_URL ?= "git://github.com:xen-troops/pvr_km.git"
 BRANCH ?= "master"
 
-SRC_URI ?= "${PVRKM_URL};protocol=ssh;branch=${BRANCH}"
+SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${BRANCH}"
 
 S = "${WORKDIR}/git"
 B = "${KBUILD_DIR}"


### PR DESCRIPTION
bitbake.conf will override any weak SRC_URIs with an empty
line, thus if SRC_URI is not set in a .bbappend file it won't
be set from .bb because of this. Make regular assignment in .bb,
still allowing .bbappend to override this.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>