### PR TITLE
kmscube: Add mesa as a build dependency

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-graphics/kmscube/kmscube_git.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-graphics/kmscube/kmscube_git.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Demo application to showcase 3D graphics using kms and gbm"
 HOMEPAGE = "https://cgit.freedesktop.org/mesa/kmscube/"
 LICENSE = "MIT"
 SECTION = "graphics"
-DEPENDS = "virtual/libgles2 virtual/egl libdrm libgbm gstreamer1.0 gstreamer1.0-plugins-base"
+DEPENDS = "mesa virtual/libgles2 virtual/egl libdrm libgbm gstreamer1.0 gstreamer1.0-plugins-base"
 
 LIC_FILES_CHKSUM = "file://kmscube.c;beginline=1;endline=23;md5=8b309d4ee67b7315ff7381270dd631fb"
 


### PR DESCRIPTION
Mesa dependency was missed resulting in build error:

/usr/include/EGL/eglext.h:1210:10: fatal error: EGL/eglmesaext.h: No such file or directory
 #include <EGL/eglmesaext.h>
          ^~~~~~~~~~~~~~~~~~
compilation terminated.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>