### PR TITLE
Swith to Renesas Yocto 3.9.0

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-kernel/linux/linux-generic-armv8.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-kernel/linux/linux-generic-armv8.bb
@@ -15,7 +15,7 @@ python () {
 KMETA = "kernel-meta"
 
 LINUX_KERNEL_TYPE = "tiny"
-LINUX_VERSION ?= "4.14.0"
+LINUX_VERSION ?= "4.14.35"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
Use latest revision of Renesas Yocto-3.9.0 with
Linux kernel v4.14.35.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>