### PR TITLE
Extend MACHINEOVERRIDES for h3ulcb

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-xt.conf
@@ -10,4 +10,4 @@ require conf/machine/include/rcar.inc
 
 UBOOT_MACHINE = "h3ulcb_defconfig"
 
-MACHINEOVERRIDES .= ":ulcb:rcar"
+MACHINEOVERRIDES .= ":ulcb:rcar:r8a7795-es2"


### PR DESCRIPTION
h3ulcb-xt (the first machine we are going to support) is based
on r8a7795-es2.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Reviewed-by: Andrii Anisov <andrii_anisov@epam.com>