### PR TITLE
Rename salvator-x-m3n-xt to salvator-xs-m3n-xt

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-m3n-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-m3n-xt.conf
@@ -1,10 +1,10 @@
 #@TYPE: Machine
-#@NAME: Salvator-X M3N machine
-#@DESCRIPTION: Machine configuration for running xen domain on Salvator-X M3N
+#@NAME: Salvator-XS M3N machine
+#@DESCRIPTION: Machine configuration for running xen domain on Salvator-XS M3N
 
 SOC_FAMILY = "r8a77965"
 
-XT_CANONICAL_MACHINE_NAME = "salvator-x"
+XT_CANONICAL_MACHINE_NAME = "salvator-xs"
 
 require conf/machine/include/rcar.inc
 


### PR DESCRIPTION
And update its content to follow Salvator-XS name.

The reason is that configuration we do support is "Salvator-XS+M3N",
but not "Salvator-X+M3N".

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>