### PR TITLE
Move 'meta-xt-prod-extra' layer down

### DIFF
--- a/inc/agl.inc
+++ b/inc/agl.inc
@@ -16,10 +16,10 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 
 # these layers will be added to bblayers.conf on do_configure
 XT_QUIRK_BB_ADD_LAYER += " \
-    meta-xt-images-domx \
     meta-virtualization \
     meta-selinux \
     meta-clang \
+    meta-xt-images-domx \
 "
 
 # Set default revision of AGL auxiliary layers


### PR DESCRIPTION
We need .bb files first and then .bbappend, i.e. xen.bb from
'meta-virtualization' and then xen.bbappend from
'meta-xt-prod-extra', so lets add 'meta-xt-prod-extra' last.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>