### PR TITLE
Introduce agl-image-minimal image target

### DIFF
--- a/recipes-domd/domd-agl-image-minimal/domd-agl-image-minimal.bb
+++ b/recipes-domd/domd-agl-image-minimal/domd-agl-image-minimal.bb
@@ -1,0 +1,4 @@
+require inc/agl.inc
+require inc/agl_domd.inc
+
+XT_BB_IMAGE_TARGET = "agl-image-minimal"


### PR DESCRIPTION
Add recipe for AGL based minimal rootfs image in case we
need minimal board support features i.e prod-AOS.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>