### PR TITLE
RFC: Turn bbappend into include file

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
@@ -2,6 +2,10 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbb4b1bdc2c3b6743da3c39d03249095"
 
+XEN_REL = "4.10"
+PV = "${XEN_REL}.0+git${SRCPV}"
+SRCREV = "${AUTOREV}"
+
 DEPENDS += "u-boot-mkimage-native systemd"
 
 PACKAGECONFIG ?= " \


### PR DESCRIPTION
This would make easier supporting products with different XEN and yocto versions.

This also requires correspondent changes in all product layers. E.g. for [meta-xt-prod-devel](https://github.com/xen-troops/meta-xt-prod-devel/pull/130).