### PR TITLE
Introduce XEN 4.12 to rocko glue file

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.12-rocko.inc
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.12-rocko.inc
@@ -1,0 +1,24 @@
+require xen-4.10-rocko.inc
+
+XEN_REL = "4.12"
+PV = "${XEN_REL}.0+git${SRCPV}"
+SRCREV = "${AUTOREV}"
+
+FILES_${PN}-libfsimage = "${libdir}/libxenfsimage.so.*"
+
+FILES_${PN}-libfsimage-dev = " \
+    ${libdir}/libxenfsimage.so \
+    ${datadir}/pkgconfig/fsimage.pc \
+    "
+
+FILES_${PN}-fsimage = "${libdir}/xenfsimage/*/fsimage.so"
+
+FILES_${PN}-misc_append = "\
+    ${libdir}/xen/bin/depriv-fd-checker \
+    "
+
+FILES_${PN}-xenmon = "\
+    ${sbindir}/xenbaked \
+    ${sbindir}/xentrace_setmask \
+    ${sbindir}/xenmon \
+    "


### PR DESCRIPTION
Because XEN 4.12 in fact does not differ much from XEN 4.10 in terms
of produced binaries, the 4.10 glue file is used as a base.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>