### PR TITLE
optee: use XT OP-TEE with virtualization enabled

### DIFF
--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -1,2 +1,39 @@
 # Prevent installing optee-os binaries into the image rootfs
 ALLOW_EMPTY_${PN} = "1"
+
+SRC_URI = " git://github.com/xen-troops/optee_os.git"
+
+LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+
+SRCREV = "master"
+PV = "3.4.0+git${SRCPV}"
+
+OPTEEMACHINE = "rcar"
+
+OPTEEFLAVOR_m3ulcb-xt = "salvator_m3"
+OPTEEFLAVOR_salvator-x-m3-xt = "salvator_m3"
+
+OPTEEFLAVOR_salvator-h3ulcb-xt = "salvator_h3"
+OPTEEFLAVOR_salvator-x-h3-xt = "salvator_h3"
+OPTEEFLAVOR_salvator-xs-h3-xt = "salvator_h3"
+OPTEEFLAVOR_salvator-xs-h3-2x2g-xt = "salvator_h3"
+
+OPTEEFLAVOR_salvator-x-h3-4x2g-xt = "salvator_h3_4x2g"
+OPTEEFLAVOR_salvator-xs-h3-4x2g-xt = "salvator_h3_4x2g"
+
+EXTRA_OEMAKE = "PLATFORM=rcar \
+	       PLATFORM_FLAVOR=${OPTEEFLAVOR} \
+	       CFG_ARM64_core=y \
+	       CFG_VIRTUALIZATION=y \
+	       CROSS_COMPILE_core=${HOST_PREFIX} \
+	       CROSS_COMPILE_ta_arm64=${HOST_PREFIX} \
+	       ta-targets=ta_arm64 \
+	       CFLAGS64=--sysroot=${STAGING_DIR_HOST} \
+	       "
+
+do_configure() {
+}
+
+do_compile() {
+	oe_runmake
+}

--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -29,6 +29,9 @@ EXTRA_OEMAKE = "PLATFORM=rcar \
 	       CROSS_COMPILE_ta_arm64=${HOST_PREFIX} \
 	       ta-targets=ta_arm64 \
 	       CFLAGS64=--sysroot=${STAGING_DIR_HOST} \
+	       CFG_SYSTEM_PTA=y \
+	       CFG_ASN1_PARSER=y \
+	       CFG_CORE_MBEDTLS_MPI=n \
 	       "
 
 do_configure() {


### PR DESCRIPTION
This patch reverts most of the changes done in renesas's optee_os
recipe in favor to generic recipe from meta-linaro.

Also it uses our own OP-TEE branch.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>