### PR TITLE
doma: Do not propagate TARGET_PREBUILT_KERNEL

### DIFF
--- a/recipes-domu/domu-image-android/domu-image-android.bb
+++ b/recipes-domu/domu-image-android/domu-image-android.bb
@@ -50,7 +50,6 @@ update_local_conf() {
 
     if [ ! -z ${XT_ANDROID_PREBUILDS_DIR} ];then
         base_set_conf_value ${local_conf} DDK_KM_PREBUILT_MODULE "${XT_ANDROID_PREBUILDS_DIR}/pvr-km/pvrsrvkm.ko"
-        base_set_conf_value ${local_conf} TARGET_PREBUILT_KERNEL "${XT_ANDROID_PREBUILDS_DIR}/kernel/vmlinux"
         base_set_conf_value ${local_conf} DDK_UM_PREBUILDS "${XT_ANDROID_PREBUILDS_DIR}/pvr-um/"
     fi
 }


### PR DESCRIPTION
TARGET_PREBUILT_KERNEL is not needed now, because
kernel for android is opensource.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>