### PR TITLE
doma: Change condition for Android prebuilds

### DIFF
--- a/recipes-domu/domu-image-android/files/0005-fetch2-repo-Add-group-parameter.patch
+++ b/recipes-domu/domu-image-android/files/0005-fetch2-repo-Add-group-parameter.patch
@@ -16,7 +16,7 @@ index ff4d548..ba6df27 100644
          bb.utils.mkdirhier(ud.repodir)
          bb.fetch2.check_network_access(d, "repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), ud.url)
 -        runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=ud.repodir)
-+        prebuilds = d.getVar("TARGET_PREBUILT_KERNEL") or ""
++        prebuilds = d.getVar("DDK_UM_PREBUILDS") or ""
 +        if prebuilds:
 +            runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=ud.repodir)
 +        else:


### PR DESCRIPTION
Android repo supports 2 variants of initialization:
1) Full source included closed source components
2) Without internal repositories

The second variant implies that closed repositories will be substituted by prebuilt binaries.
DDK_UM_PREBUILDS is a must-have condition for any prebuilds.
Changing repo condition to it, since TARGET_PREBUILT_KERNEL is optional.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>