### PR TITLE
optee-os: deploy tee_raw.bin

### DIFF
--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -41,3 +41,7 @@ do_configure() {
 do_compile() {
 	oe_runmake
 }
+
+do_deploy_append() {
+	install -m 0644 ${S}/out/arm-plat-${PLATFORM}/core/tee_raw.bin ${DEPLOYDIR}/tee_raw-${MACHINE}.bin
+}


### PR DESCRIPTION
tee_raw.bin is a header-less image of OP-TEE OS. This binary is mainly
used to flash OP-TEE using in-circuit debugger.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>