### PR TITLE
xen: use xen-v4.12 recipe as a separate one

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
@@ -1,70 +1,9 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
+require xen-common.inc
 LIC_FILES_CHKSUM = "file://COPYING;md5=bbb4b1bdc2c3b6743da3c39d03249095"
 
 XEN_REL = "4.10"
 PV = "${XEN_REL}.0+git${SRCPV}"
 SRCREV = "${AUTOREV}"
-
-DEPENDS += "u-boot-mkimage-native systemd"
-
-PACKAGECONFIG ?= " \
-    xsm \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)} \
-    ${@bb.utils.contains('XEN_TARGET_ARCH', 'x86_64', 'hvm', '', d)} \
-    "
-
-EXTRA_OEMAKE += " CONFIG_HAS_SCIF=y CONFIG_QEMU_XEN=n"
-
-RDEPENDS_${PN}-base += "\
-    ${PN}-livepatch \
-    "
-
-RDEPENDS_${PN}-base_remove += " \
-    ${PN}-blktap \
-    ${PN}-libblktapctl \
-    ${PN}-libvhd \
-    "
-
-RRECOMMENDS_${PN}-base += " \
-    ${PN}-blktap \
-    ${PN}-libblktapctl \
-    ${PN}-libvhd \
-    "
-
-FILES_${PN}-hypervisor += "\
-    /usr/lib/debug/xen-syms-* \
-    "
-
-FILES_${PN}-scripts-block += " \
-    ${sysconfdir}/xen/scripts/block-dummy \
-    "
-
-FILES_${PN}-scripts-network += " \
-    ${sysconfdir}/xen/scripts/colo-proxy-setup \
-    "
-
-FILES_${PN}-staticdev += "\
-    ${exec_prefix}/lib64/libxenstore.a \
-    ${exec_prefix}/lib64/libxenvchan.a \
-    "
-
-FILES_${PN}-xencommons += " \
-    ${systemd_unitdir}/system/xendriverdomain.service \
-    ${sysconfdir}/xen/scripts/launch-xenstore \
-    "
-
-FILES_${PN}-xencommons_remove += " \
-    ${systemd_unitdir}/system/xenstored.socket \
-    ${systemd_unitdir}/system/xenstored_ro.socket \
-    "
-
-FILES_${PN}-libxendevicemodel = "${libdir}/libxendevicemodel.so.*"
-FILES_${PN}-libxendevicemodel-dev = "${libdir}/libxendevicemodel.so"
-
-FILES_${PN}-pkgconfig = "\
-    ${datadir}/pkgconfig \
-    "
 
 FILES_${PN}-libxentoolcore = "${libdir}/libxentoolcore.so.*"
 FILES_${PN}-libxentoolcore-dev = " \
@@ -76,22 +15,4 @@ PACKAGES_append = "\
     ${PN}-pkgconfig \
     ${PN}-libxentoolcore \
     ${PN}-libxentoolcore-dev \
-    "
-
-SYSTEMD_SERVICE_${PN}-xencommons += " \
-    xendriverdomain.service \
-    "
-
-SYSTEMD_SERVICE_${PN}-xencommons_remove += " \
-    xenstored.socket \
-    xenstored_ro.socket \
-    "
-
-RDEPENDS_${PN}-efi = " \
-    bash \
-    python \
-    "
-
-FILES_${PN}-misc_append = "\
-    ${sbindir}/xen-diag \
     "

--- a/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.12-rocko.inc
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-4.12-rocko.inc
@@ -1,4 +1,5 @@
-require xen-4.10-rocko.inc
+require xen-common.inc
+LIC_FILES_CHKSUM = "file://COPYING;md5=bbb4b1bdc2c3b6743da3c39d03249095"
 
 XEN_REL = "4.12"
 PV = "${XEN_REL}.0+git${SRCPV}"

--- a/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-common.inc
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/xen/xen-common.inc
@@ -1,0 +1,81 @@
+DEPENDS += "u-boot-mkimage-native systemd"
+
+PACKAGECONFIG ?= " \
+    xsm \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)} \
+    ${@bb.utils.contains('XEN_TARGET_ARCH', 'x86_64', 'hvm', '', d)} \
+    "
+
+EXTRA_OEMAKE += " CONFIG_HAS_SCIF=y CONFIG_QEMU_XEN=n"
+
+RDEPENDS_${PN}-base += "\
+    ${PN}-livepatch \
+    "
+
+RDEPENDS_${PN}-base_remove += " \
+    ${PN}-blktap \
+    ${PN}-libblktapctl \
+    ${PN}-libvhd \
+    "
+
+RRECOMMENDS_${PN}-base += " \
+    ${PN}-blktap \
+    ${PN}-libblktapctl \
+    ${PN}-libvhd \
+    "
+
+FILES_${PN}-hypervisor += "\
+    /usr/lib/debug/xen-syms-* \
+    "
+
+FILES_${PN}-scripts-block += " \
+    ${sysconfdir}/xen/scripts/block-dummy \
+    "
+
+FILES_${PN}-scripts-network += " \
+    ${sysconfdir}/xen/scripts/colo-proxy-setup \
+    "
+
+FILES_${PN}-staticdev += "\
+    ${exec_prefix}/lib64/libxenstore.a \
+    ${exec_prefix}/lib64/libxenvchan.a \
+    "
+
+FILES_${PN}-xencommons += " \
+    ${systemd_unitdir}/system/xendriverdomain.service \
+    ${sysconfdir}/xen/scripts/launch-xenstore \
+    "
+
+FILES_${PN}-xencommons_remove += " \
+    ${systemd_unitdir}/system/xenstored.socket \
+    ${systemd_unitdir}/system/xenstored_ro.socket \
+    "
+
+FILES_${PN}-libxendevicemodel = "${libdir}/libxendevicemodel.so.*"
+FILES_${PN}-libxendevicemodel-dev = "${libdir}/libxendevicemodel.so"
+
+FILES_${PN}-pkgconfig = "\
+    ${datadir}/pkgconfig \
+    "
+
+PACKAGES_append = "\
+    ${PN}-pkgconfig \
+"
+
+SYSTEMD_SERVICE_${PN}-xencommons += " \
+    xendriverdomain.service \
+    "
+
+SYSTEMD_SERVICE_${PN}-xencommons_remove += " \
+    xenstored.socket \
+    xenstored_ro.socket \
+    "
+
+RDEPENDS_${PN}-efi = " \
+    bash \
+    python \
+    "
+
+FILES_${PN}-misc_append = "\
+    ${sbindir}/xen-diag \
+    "


### PR DESCRIPTION
Newer revision of meta-virtualization layer already contains
recipe for xen-v4.10 so we have got conflict duplication
xen-libxentoolcore in PACKAGES variable since
commit: 8cf0a585e04482627c22a70585f64b183725c370 so,
we have to split them up.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>