### PR TITLE
displaymanager: use libdbus-c++ from meta-oe instead...

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-extended/displaymanager/displaymanager_git.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/displaymanager/displaymanager_git.bb
@@ -3,7 +3,7 @@ SECTION = "extras"
 LICENSE = "GPLv2"
 PR = "r0"
 
-DEPENDS = "libxenbe libconfig wayland-ivi-extension dbus-cpp git-native"
+DEPENDS = "libconfig wayland-ivi-extension dbus-cxx git-native xt-log"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 


### PR DESCRIPTION
of dbus-c++.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>