### PR TITLE
domd: fix PVRUM postinstall script failure

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
@@ -27,7 +27,7 @@ SRC_URI_append = " \
 
 inherit update-rc.d systemd
 
-INITSCRIPT_NAME = "pvrinit"
+INITSCRIPT_NAME = "rc.pvr"
 INITSCRIPT_PARAMS = "start 7 5 2 . stop 62 0 1 6 ."
 SYSTEMD_SERVICE_${PN} = "rc.pvr.service"
 


### PR DESCRIPTION
During do_rootfs command following message was shown:
ERROR: Postinstall scriptlets of ['gles-user-module'] have failed.
If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget_${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
The reason - variable INITSCRIPT_NAME is wrong, so fix it.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>