### PR TITLE
Add OPTEEFLAVOR for salvator-xs-m3n machine

### DIFF
--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -10,6 +10,8 @@ PV = "3.4.0+git${SRCPV}"
 
 OPTEEMACHINE = "rcar"
 
+OPTEEFLAVOR_salvator-xs-m3n-xt = "salvator_m3n"
+
 OPTEEFLAVOR_m3ulcb-xt = "salvator_m3"
 OPTEEFLAVOR_salvator-x-m3-xt = "salvator_m3"
 


### PR DESCRIPTION
The PLATFORM_FLAVOR_salvator_m3n should be added to OPTEE-OS.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>