### PR TITLE
Remove duplicated 'rcar' from MACHINEOVERRIDES

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-4x2g-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-4x2g-xt.conf
@@ -10,4 +10,4 @@ require conf/machine/include/rcar.inc
 
 UBOOT_MACHINE = "r8a7795_ulcb-4x2g_defconfig"
 
-MACHINEOVERRIDES .= ":ulcb:rcar:r8a7795-es3"
+MACHINEOVERRIDES .= ":ulcb:r8a7795-es3"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-xt.conf
@@ -10,4 +10,4 @@ require conf/machine/include/rcar.inc
 
 UBOOT_MACHINE = "r8a7795_ulcb_defconfig"
 
-MACHINEOVERRIDES .= ":ulcb:rcar:r8a7795-es2"
+MACHINEOVERRIDES .= ":ulcb:r8a7795-es2"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/m3ulcb-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/m3ulcb-xt.conf
@@ -10,4 +10,4 @@ require conf/machine/include/rcar.inc
 
 UBOOT_MACHINE = "r8a7796_ulcb_defconfig"
 
-MACHINEOVERRIDES .= ":ulcb:rcar"
+MACHINEOVERRIDES .= ":ulcb"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-4x2g-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-4x2g-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # H3 u-boot configure
 UBOOT_MACHINE = "r8a7795_salvator-x-4x2g_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar:r8a7795-es3"
+MACHINEOVERRIDES .= ":salvator:r8a7795-es3"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-h3-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # H3 u-boot configure
 UBOOT_MACHINE = "r8a7795_salvator-x_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar:r8a7795-es2"
+MACHINEOVERRIDES .= ":salvator:r8a7795-es2"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-m3-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-x-m3-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # M3 u-boot configure
 UBOOT_MACHINE = "r8a7796_salvator-x_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar"
+MACHINEOVERRIDES .= ":salvator"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-h3-2x2g-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-h3-2x2g-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # H3 u-boot configure
 UBOOT_MACHINE = "r8a7795_salvator-xs-2x2g_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar:r8a7795-es3"
+MACHINEOVERRIDES .= ":salvator:r8a7795-es3"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-h3-4x2g-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-h3-4x2g-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # H3 u-boot configure
 UBOOT_MACHINE = "r8a7795_salvator-xs-4x2g_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar:r8a7795-es3"
+MACHINEOVERRIDES .= ":salvator:r8a7795-es3"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-h3-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-h3-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # H3 u-boot configure
 UBOOT_MACHINE = "r8a7795_salvator-xs_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar:r8a7795-es2"
+MACHINEOVERRIDES .= ":salvator:r8a7795-es2"

--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-m3n-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-m3n-xt.conf
@@ -11,4 +11,4 @@ require conf/machine/include/rcar.inc
 # M3N u-boot configure
 UBOOT_MACHINE = "r8a77965_salvator-xs_defconfig"
 
-MACHINEOVERRIDES .= ":salvator:rcar"
+MACHINEOVERRIDES .= ":salvator"


### PR DESCRIPTION
'rcar' is added inside local.conf.rcar-domd-image-weston in meta-xt-prod-devel project
See recipes-domd/domd-image-weston/files/meta-xt-prod-extra/doc/ folder.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>