### PR TITLE
Add missed XT_CANONICAL_MACHINE_NAME for h3ulcb-4x2g-kf

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-4x2g-kf-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-4x2g-kf-xt.conf
@@ -4,4 +4,6 @@
 
 require h3ulcb-4x2g-xt.conf
 
+XT_CANONICAL_MACHINE_NAME = "h3ulcb-4x2g-kf"
+
 MACHINEOVERRIDES .= ":kingfisher"


### PR DESCRIPTION
So far the "h3ulcb-4x2g-kf" machine has used a canonical name borrowed
from the parent machine which is "h3ulcb-4x2g".

Set the proper canonical name for the gstreamer1.0-plugin-vspfilter
recipe to be able to properly determine which gstvspfilter config to
pick up and deploy.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Reviewed-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>