### PR TITLE
Re-implement repo patches

### DIFF
--- a/recipes-domu/domu-image-android/files/0001-fetch2-repo-Always-check-if-branch-is-correct.patch
+++ b/recipes-domu/domu-image-android/files/0001-fetch2-repo-Always-check-if-branch-is-correct.patch
@@ -1,6 +1,6 @@
-From a733c75f3a0918d85e433e4fc567cb3b9949858b Mon Sep 17 00:00:00 2001
-From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
-Date: Tue, 24 Oct 2017 10:04:03 +0300
+From 6796c893f5f8ff38096aa15d44c21164a5974b79 Mon Sep 17 00:00:00 2001
+From: Usyk Ihor <ihor_usyk@epam.com>
+Date: Fri, 13 Dec 2019 15:07:17 +0100
 Subject: [PATCH 1/4] fetch2/repo: Always check if branch is correct
 
 Current implementation doesn't pay attention if
@@ -11,25 +11,30 @@ repo init/sync.
 
 Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 ---
- bitbake/lib/bb/fetch2/repo.py | 5 ++---
- 1 file changed, 2 insertions(+), 3 deletions(-)
+ bitbake/lib/bb/fetch2/repo.py | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 1be91cc698e3..6b2efa2b91f8 100644
+index 8c7e81853a..e92640ff18 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
-@@ -70,9 +70,8 @@ class Repo(FetchMethod):
+@@ -73,12 +73,11 @@ class Repo(FetchMethod):
  
          repodir = os.path.join(codir, "repo")
          bb.utils.mkdirhier(repodir)
 -        if not os.path.exists(os.path.join(repodir, ".repo")):
--            bb.fetch2.check_network_access(d, "repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), ud.url)
--            runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=repodir)
+-            bb.fetch2.check_network_access(d, "%s init -m %s -b %s -u %s://%s%s%s" % (ud.basecmd, ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), ud.url)
+-            runfetchcmd("%s init -m %s -b %s -u %s://%s%s%s" % (ud.basecmd, ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=repodir)
 +        bb.fetch2.check_network_access(d, "repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), ud.url)
 +        runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=repodir)
  
-         bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
-         runfetchcmd("repo sync", d, workdir=repodir)
+-        bb.fetch2.check_network_access(d, "%s sync %s" % (ud.basecmd, ud.url), ud.url)
+-        runfetchcmd("%s sync" % ud.basecmd, d, workdir=repodir)
++        bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
++        runfetchcmd("repo sync", d, workdir=repodir)
+ 
+         scmdata = ud.parm.get("scmdata", "")
+         if scmdata == "keep":
 -- 
-2.7.4
+2.17.1
 

--- a/recipes-domu/domu-image-android/files/0002-fetch2-repo-Make-fetcher-always-sync-on-unpack.patch
+++ b/recipes-domu/domu-image-android/files/0002-fetch2-repo-Make-fetcher-always-sync-on-unpack.patch
@@ -1,6 +1,6 @@
-From d8cc9c16df233abfc39efbc04e37a795134588bd Mon Sep 17 00:00:00 2001
-From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
-Date: Thu, 26 Oct 2017 17:16:49 +0300
+From 295b04aea3be8134bdaaf2b4aeb00914120f95a3 Mon Sep 17 00:00:00 2001
+From: Usyk Ihor <ihor_usyk@epam.com>
+Date: Fri, 13 Dec 2019 15:26:46 +0100
 Subject: [PATCH 2/4] fetch2/repo: Make fetcher always sync on unpack
 
 Currently if repo has fetched the repository and
@@ -9,16 +9,16 @@ thus making the build use potentially outdated repo.
 Fix this by implementing unpack functionality which runs
 repo sync.
 
-Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
+Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com> 
 ---
- bitbake/lib/bb/fetch2/repo.py | 22 +++++++++++++---------
- 1 file changed, 13 insertions(+), 9 deletions(-)
+ bitbake/lib/bb/fetch2/repo.py | 24 ++++++++++++++----------
+ 1 file changed, 14 insertions(+), 10 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 6b2efa2b91f8..d51d1ebf7a07 100644
+index e92640ff18..704e84390f 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
-@@ -51,6 +51,10 @@ class Repo(FetchMethod):
+@@ -54,6 +54,11 @@ class Repo(FetchMethod):
              ud.manifest += '.xml'
  
          ud.localfile = d.expand("repo_%s%s_%s_%s.tar.gz" % (ud.host, ud.path.replace("/", "."), ud.manifest, ud.branch))
@@ -26,22 +26,23 @@ index 6b2efa2b91f8..d51d1ebf7a07 100644
 +        gitsrcname = "%s%s" % (ud.host, ud.path.replace("/", "."))
 +        ud.codir = os.path.join(repodir, gitsrcname, ud.manifest)
 +        ud.repodir = os.path.join(ud.codir, "repo")
++
  
      def download(self, ud, d):
          """Fetch url"""
-@@ -59,22 +63,17 @@ class Repo(FetchMethod):
+@@ -62,22 +67,16 @@ class Repo(FetchMethod):
              logger.debug(1, "%s already exists (or was stashed). Skipping repo init / sync.", ud.localpath)
              return
  
+-        repodir = d.getVar("REPODIR") or (d.getVar("DL_DIR") + "/repo")
 -        gitsrcname = "%s%s" % (ud.host, ud.path.replace("/", "."))
--        repodir = d.getVar("REPODIR") or os.path.join(d.getVar("DL_DIR"), "repo")
 -        codir = os.path.join(repodir, gitsrcname, ud.manifest)
 -
          if ud.user:
              username = ud.user + "@"
          else:
              username = ""
- 
+-
 -        repodir = os.path.join(codir, "repo")
 -        bb.utils.mkdirhier(repodir)
 +        bb.utils.mkdirhier(ud.repodir)
@@ -55,7 +56,7 @@ index 6b2efa2b91f8..d51d1ebf7a07 100644
  
          scmdata = ud.parm.get("scmdata", "")
          if scmdata == "keep":
-@@ -83,7 +82,12 @@ class Repo(FetchMethod):
+@@ -86,7 +85,12 @@ class Repo(FetchMethod):
              tar_flags = "--exclude='.repo' --exclude='.git'"
  
          # Create a cache
@@ -70,5 +71,5 @@ index 6b2efa2b91f8..d51d1ebf7a07 100644
      def supports_srcrev(self):
          return False
 -- 
-2.7.4
+2.17.1
 

--- a/recipes-domu/domu-image-android/files/0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch
+++ b/recipes-domu/domu-image-android/files/0003-fetch2-repo-Use-multiple-jobs-to-fetch-and-sync.patch
@@ -1,6 +1,6 @@
-From 199868288780e6eaa0a7632d2de80e2c84f9d73d Mon Sep 17 00:00:00 2001
-From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
-Date: Tue, 24 Oct 2017 10:14:14 +0300
+From 2c230f73f6892aa318f90f4c519280927a2120a7 Mon Sep 17 00:00:00 2001
+From: Usyk Ihor <ihor_usyk@epam.com>
+Date: Fri, 13 Dec 2019 15:29:13 +0100
 Subject: [PATCH 3/4] fetch2/repo: Use multiple jobs to fetch and sync
 
 Google repo supports "--jobs" parameter, so one can
@@ -12,14 +12,14 @@ Use BB_NUMBER_THREADS to run parallel repo sync.
 
 Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
 ---
- bitbake/lib/bb/fetch2/repo.py | 11 +++++++++--
- 1 file changed, 9 insertions(+), 2 deletions(-)
+ bitbake/lib/bb/fetch2/repo.py | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index d51d1ebf7a07..0ed0f923f6a4 100644
+index 704e84390f..2d9080c9d5 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
-@@ -56,6 +56,13 @@ class Repo(FetchMethod):
+@@ -59,6 +59,12 @@ class Repo(FetchMethod):
          ud.codir = os.path.join(repodir, gitsrcname, ud.manifest)
          ud.repodir = os.path.join(ud.codir, "repo")
  
@@ -29,11 +29,10 @@ index d51d1ebf7a07..0ed0f923f6a4 100644
 +        num_jobs = d.getVar("BB_NUMBER_THREADS", True) or "1"
 +        runfetchcmd("repo sync -c -n -j%s" % num_jobs, d, workdir=destdir)
 +        runfetchcmd("repo sync -c -l -j%s" % num_jobs, d, workdir=destdir)
-+
+ 
      def download(self, ud, d):
          """Fetch url"""
- 
-@@ -73,7 +80,7 @@ class Repo(FetchMethod):
+@@ -76,7 +82,7 @@ class Repo(FetchMethod):
          runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=ud.repodir)
  
          bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
@@ -42,7 +41,7 @@ index d51d1ebf7a07..0ed0f923f6a4 100644
  
          scmdata = ud.parm.get("scmdata", "")
          if scmdata == "keep":
-@@ -87,7 +94,7 @@ class Repo(FetchMethod):
+@@ -90,7 +96,7 @@ class Repo(FetchMethod):
      def unpack(self, ud, destdir, d):
          FetchMethod.unpack(self, ud, destdir, d)
          bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
@@ -52,5 +51,5 @@ index d51d1ebf7a07..0ed0f923f6a4 100644
      def supports_srcrev(self):
          return False
 -- 
-2.7.4
+2.17.1
 

--- a/recipes-domu/domu-image-android/files/0004-Make-pack-unpack-multithreaded.patch
+++ b/recipes-domu/domu-image-android/files/0004-Make-pack-unpack-multithreaded.patch
@@ -1,6 +1,6 @@
-From 6526322512920e9b020fffe948100d024ee19774 Mon Sep 17 00:00:00 2001
-From: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
-Date: Fri, 29 Dec 2017 17:26:49 +0200
+From afd92b984d568638b8517497fd0112f46e1d8207 Mon Sep 17 00:00:00 2001
+From: Usyk Ihor <ihor_usyk@epam.com>
+Date: Fri, 13 Dec 2019 15:31:27 +0100
 Subject: [PATCH 4/4] Make pack/unpack multithreaded
 
 Use pigz/unpigz to make fetcher's pack/unpack tar
@@ -14,10 +14,10 @@ Signed-off-by: Artem Mygaiev <artem_mygaiev@epam.com>
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/bitbake/lib/bb/fetch2/__init__.py b/bitbake/lib/bb/fetch2/__init__.py
-index b853da30bdbf..2a0f875dd394 100644
+index 03e56471d8..cb373bd210 100644
 --- a/bitbake/lib/bb/fetch2/__init__.py
 +++ b/bitbake/lib/bb/fetch2/__init__.py
-@@ -1398,7 +1398,7 @@ class FetchMethod(object):
+@@ -1430,7 +1430,7 @@ class FetchMethod(object):
  
          if unpack:
              if file.endswith('.tar'):
@@ -27,10 +27,10 @@ index b853da30bdbf..2a0f875dd394 100644
                  cmd = 'tar xz --no-same-owner -f %s' % file
              elif file.endswith('.tbz') or file.endswith('.tbz2') or file.endswith('.tar.bz2'):
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index 0ed0f923f6a4..adf437a24e32 100644
+index 2d9080c9d5..a60e82f358 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
-@@ -89,7 +89,7 @@ class Repo(FetchMethod):
+@@ -91,7 +91,7 @@ class Repo(FetchMethod):
              tar_flags = "--exclude='.repo' --exclude='.git'"
  
          # Create a cache
@@ -40,5 +40,5 @@ index 0ed0f923f6a4..adf437a24e32 100644
      def unpack(self, ud, destdir, d):
          FetchMethod.unpack(self, ud, destdir, d)
 -- 
-2.7.4
+2.17.1
 

--- a/recipes-domu/domu-image-android/files/0005-fetch2-repo-Add-group-parameter.patch
+++ b/recipes-domu/domu-image-android/files/0005-fetch2-repo-Add-group-parameter.patch
@@ -1,18 +1,19 @@
-From f9b84d2ae9af8e4aa23f3d29b2c5675b80a38c1f Mon Sep 17 00:00:00 2001
-From: xen-troops-buildbot <not.real.email@epam.com>
-Date: Tue, 11 Dec 2018 15:10:42 +0000
+From ac82f99b3346458b19b829788ee42a2bf805c6da Mon Sep 17 00:00:00 2001
+From: Usyk Ihor <ihor_usyk@epam.com>
+Date: Fri, 13 Dec 2019 15:34:22 +0100
 Subject: [PATCH] Add group parameter
 
+Signed-off-by: Usyk Ihor <ihor_usyk@epam.com>
 ---
  bitbake/lib/bb/fetch2/repo.py | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/bitbake/lib/bb/fetch2/repo.py b/bitbake/lib/bb/fetch2/repo.py
-index ff4d548..ba6df27 100644
+index a60e82f358..8ba0e4ec2c 100644
 --- a/bitbake/lib/bb/fetch2/repo.py
 +++ b/bitbake/lib/bb/fetch2/repo.py
-@@ -77,7 +77,11 @@ class Repo(FetchMethod):
-
+@@ -79,7 +79,11 @@ class Repo(FetchMethod):
+             username = ""
          bb.utils.mkdirhier(ud.repodir)
          bb.fetch2.check_network_access(d, "repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), ud.url)
 -        runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=ud.repodir)
@@ -21,8 +22,9 @@ index ff4d548..ba6df27 100644
 +            runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path), d, workdir=ud.repodir)
 +        else:
 +            runfetchcmd("repo init -m %s -b %s -u %s://%s%s%s -g %s" % (ud.manifest, ud.branch, ud.proto, username, ud.host, ud.path, "all"), d, workdir=ud.repodir)
-
+ 
          bb.fetch2.check_network_access(d, "repo sync %s" % ud.url, ud.url)
          self.sync(ud.repodir, d)
---
-2.7.4
+-- 
+2.17.1
+


### PR DESCRIPTION
Existed patches are incompatble

incompatible with current versions(thud) of the repo.py and __init__.py
path:poky/bitbake/lib/bb/fetch2

Signed-off-by: Usyk Ihor <ihor_usyk@epam.com>

see issue https://github.com/xen-troops/meta-xt-images/issues/143 for the details