### PR TITLE
optee_os: temp: Set fixed component`s revision for now

### DIFF
--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -5,7 +5,7 @@ SRC_URI = " git://github.com/xen-troops/optee_os.git"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 
-SRCREV = "master"
+SRCREV = "4579fd7a66721bc5c7a4912c2e2a65e5684943cf"
 PV = "3.4.0+git${SRCPV}"
 
 OPTEEMACHINE = "rcar"


### PR DESCRIPTION
In order to fix optee_os for Prod-devel REL-v4.0.

TODO: Every product's meta layer (which requires optee_os to
be built) should contain bbappend file with corresponding
SRC_URI/LIC_FILES_CHKSUM/SRCREV values.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>