### PR TITLE
doma: Remove ccache from Android build

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
+++ b/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
@@ -26,11 +26,6 @@ ANDROID_PRODUCT ?= "aosp_arm64"
 ANDROID_VARIANT ?= "eng"
 SOC_FAMILY ?= "default"
 
-ANDROID_CCACHE_BIN_DIR = "prebuilts/misc/linux-x86/ccache"
-ANDROID_CCACHE_SIZE_GB = "50"
-# keep .ccache aside of Yocto's cache
-ANDROID_CCACHE_DIR = "${SSTATE_DIR}/../${PN}-${ANDROID_PRODUCT}-${ANDROID_VARIANT}-${SOC_FAMILY}-ccache"
-
 JAVA_HOME = "${STAGING_LIBDIR_JVM_NATIVE}/${JDK_VER}"
 
 ANDROID_OUT_DIR_COMMON_BASE = ""
@@ -46,14 +41,12 @@ do_compile() {
 
     # run Android build in sane environment
     env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" USER="$USER" \
-           PATH="${JAVA_HOME}/bin:${S}/${ANDROID_CCACHE_BIN_DIR}:$PATH" \
+           PATH="${JAVA_HOME}/bin:$PATH" \
            JAVA_HOME="${JAVA_HOME}" OUT_DIR_COMMON_BASE="${ANDROID_OUT_DIR_COMMON_BASE}" \
-           USE_CCACHE="1" CCACHE_DIR="${ANDROID_CCACHE_DIR}" CCACHE_BASEDIR="${S}" \
            DDK_KM_PREBUILT_MODULE="${DDK_KM_PREBUILT_MODULE}" \
            TARGET_PREBUILT_KERNEL="${TARGET_PREBUILT_KERNEL}" \
            DDK_UM_PREBUILDS="${DDK_UM_PREBUILDS}" \
-           bash -c "${ANDROID_CCACHE_BIN_DIR}/ccache -M ${ANDROID_CCACHE_SIZE_GB}G && \
-                    source build/envsetup.sh && \
+           bash -c "source build/envsetup.sh && \
                     lunch ${ANDROID_PRODUCT}-${ANDROID_VARIANT} && \
                     make ${EXTRA_OEMAKE} ${PARALLEL_MAKE} \
            "


### PR DESCRIPTION
Remove ccache from Android as it is not really used with
Android P and not supported by Android Q.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>