### PR TITLE
Support the linux ddk 1.11

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-module-egl-headers_1.11.bb
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-module-egl-headers_1.11.bb
@@ -1,0 +1,2 @@
+require gles-module-egl-headers.inc
+

--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module_1.11.bb
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module_1.11.bb
@@ -1,0 +1,24 @@
+require gles-common.inc
+require gles-user-module.inc
+
+PREFERRED_VERSION_gles-module-egl-headers = "1.11"
+
+DEPENDS += " \
+    clang-native \
+    wayland-protocols \
+"
+DEPENDS_remove = " \
+    binutils-cross-aarch64 \
+    llvmpvr \
+"
+
+PROVIDES_remove = "virtual/opencl libopencl"
+RPROVIDES_${PN}_remove = " \
+    libopencl \
+"
+EXTRA_OEMAKE += "LIBCLANG_PATH=${STAGING_LIBDIR_NATIVE}/libclang.so"
+EXTRA_OEMAKE_remove = "LLVM_BUILD_DIR=${STAGING_LIBDIR}/llvm_build_dir"
+
+EXCLUDED_APIS = ""
+EXTRA_OEMAKE += "EXCLUDED_APIS='${EXCLUDED_APIS}'"
+RDEPENDS_${PN} += "python3-core"

--- a/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles_1.11.bb
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles_1.11.bb
@@ -1,0 +1,1 @@
+require kernel-module-gles.inc


### PR DESCRIPTION
The new recipes to suppport the build with lddk 1.11 are created.
One feature is added: support thelist of the components to be excluded.
The varieble EXCLUDED_APIS is introduced into gles-module/gles-user-module_1.11.bb.
If some components are not required in the build, these variable has to initialized in the corresponded
.bbappend recipe. For example, to exclude opencl and vulkan, the variable has to be initialized like
EXCLUDED_APIS = "opencl vulkan"

Signed-off-by: Usyk Ihor <ihor.usyk@google.com>