### PR TITLE
Revert "optee_os: temp: Set fixed component`s revision for now"

### DIFF
--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -5,7 +5,7 @@ SRC_URI = " git://github.com/xen-troops/optee_os.git"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 
-SRCREV = "4579fd7a66721bc5c7a4912c2e2a65e5684943cf"
+SRCREV = "master"
 PV = "3.4.0+git${SRCPV}"
 
 OPTEEMACHINE = "rcar"


### PR DESCRIPTION
This reverts commit a6480876ccfc9c7c6e0bcb5ee418cbc4977efe29.

This was exclusively needed for setting a fixed OPTEE version
for Prod-devel REL v4.0.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>