### PR TITLE
Generate error if PVRKM_URL is not set

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
@@ -13,7 +13,7 @@ PR = "r1"
 COMPATIBLE_MACHINE = "(r8a7795|r8a7796|r8a77965)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PVRKM_URL ?= "git://github.com:xen-troops/pvr_km.git"
+PVRKM_URL ??= "PRVKM_URL is not set. Looks like incorrect settings."
 BRANCH ?= "master"
 
 SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${BRANCH}"


### PR DESCRIPTION
Set not compilable string, with explanation of error, as default value
for PVRKM_URL to avoid masking of erroneous settings of kernel_module_gles
environment.

Example of possible issue:
Product A uses DDK v1.10 and has not specified preferred version.
At some moment DDK v1.11 appears with appropriate recipe in this
project. As result kernel-module-gles_1.11.bb will be used to detect
$PV (1.11). But there is no corresponding bbappend for 1.11 inside
product A, and we will not assign proper url to PVRKM_URL, and do not
perform other required settings. But still compilation may continue
with error in some not obvious place.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>