### PR TITLE
Change xt-log's license from GPLv3 to GPLv2

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-extended/xt-log/xt-log_git.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/xt-log/xt-log_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "C++ header only log"
 SECTION = "libs"
-LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The xt-log package has changed its license from GPLv3 to GPLv2,
so update the recipe accordingly.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>