### PR TITLE
DisplayManager: Remove dbus-cxx dependency

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-extended/displaymanager/displaymanager_git.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-extended/displaymanager/displaymanager_git.bb
@@ -3,7 +3,7 @@ SECTION = "extras"
 LICENSE = "GPLv2"
 PR = "r0"
 
-DEPENDS = "libconfig wayland-ivi-extension dbus-cxx git-native xt-log"
+DEPENDS = "libconfig wayland-ivi-extension glib-2.0 glib-2.0-native git-native xt-log"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 


### PR DESCRIPTION
DisplayManager doesn't depend on dbus-cxx library now as we moved
to pure GLib implementation, so update the dependencies.

Please note that we depend on glib-2.0-native to use gdbus-codegen.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>