### PR TITLE
[WIP] Remove linaro's optee-os layer from domd-image-*

### DIFF
--- a/recipes-domd/domd-image-minimal/domd-image-minimal.bb
+++ b/recipes-domd/domd-image-minimal/domd-image-minimal.bb
@@ -4,7 +4,6 @@ require inc/domx-image-weston.inc
 
 # these layers will be added to bblayers.conf on do_configure
 XT_QUIRK_BB_ADD_LAYER += " \
-    meta-linaro/meta-optee \
 "
 
 ################################################################################

--- a/recipes-domd/domd-image-weston/domd-image-weston.bb
+++ b/recipes-domd/domd-image-weston/domd-image-weston.bb
@@ -9,7 +9,6 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 # these layers will be added to bblayers.conf on do_configure
 XT_QUIRK_BB_ADD_LAYER += " \
     meta-xt-images-vgpu \
-    meta-linaro/meta-optee \
 "
 
 ################################################################################


### PR DESCRIPTION
We use xen-troops' optee-os in
domd-image-weston
domd-image-minimal
so no need to add layer with linaro's optee-os.