### PR TITLE
Remove BBLAYERS_NON_REMOVABLE

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/doc/bblayers.conf
+++ b/machine/meta-xt-images-rcar-gen3/doc/bblayers.conf
@@ -17,7 +17,3 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-selinux \
   ${TOPDIR}/../meta-virtualization \
   "
-BBLAYERS_NON_REMOVABLE ?= " \
-  ${TOPDIR}/../poky/meta \
-  ${TOPDIR}/../poky/meta-poky \
-  "


### PR DESCRIPTION
BBLAYERS_NON_REMOVABLE was used only by Hob.
This variable was removed from yocto in March 2016 and
there is no reason for us to keep it.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>