### PR TITLE
Add the build signature to avoid the rebuild

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
+++ b/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
@@ -40,14 +40,20 @@ do_compile() {
     cd ${S}
 
     # run Android build in sane environment
-    env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" USER="$USER" \
-           PATH="${JAVA_HOME}/bin:$PATH" \
-           JAVA_HOME="${JAVA_HOME}" OUT_DIR_COMMON_BASE="${ANDROID_OUT_DIR_COMMON_BASE}" \
-           DDK_KM_PREBUILT_MODULE="${DDK_KM_PREBUILT_MODULE}" \
-           TARGET_PREBUILT_KERNEL="${TARGET_PREBUILT_KERNEL}" \
-           DDK_UM_PREBUILDS="${DDK_UM_PREBUILDS}" \
-           bash -c "source build/envsetup.sh && \
-                    lunch ${ANDROID_PRODUCT}-${ANDROID_VARIANT} && \
-                    make ${EXTRA_OEMAKE} ${PARALLEL_MAKE} \
-           "
+    if [ ! -f ${S}/.android_signature ]; then
+      env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" USER="$USER" \
+             PATH="${JAVA_HOME}/bin:$PATH" \
+             JAVA_HOME="${JAVA_HOME}" OUT_DIR_COMMON_BASE="${ANDROID_OUT_DIR_COMMON_BASE}" \
+             DDK_KM_PREBUILT_MODULE="${DDK_KM_PREBUILT_MODULE}" \
+             TARGET_PREBUILT_KERNEL="${TARGET_PREBUILT_KERNEL}" \
+             DDK_UM_PREBUILDS="${DDK_UM_PREBUILDS}" \
+             bash -c "source build/envsetup.sh && \
+                      lunch ${ANDROID_PRODUCT}-${ANDROID_VARIANT} && \
+                      make ${EXTRA_OEMAKE} ${PARALLEL_MAKE} \
+             "
+      build_signature=$(md5sum ${S}/Makefile)
+      echo ${build_signature} > ${S}/.android_signature
+   else
+      echo "${S}/.android_signature exists, no needs to rebuild."
+   fi
 }


### PR DESCRIPTION
android.bbappend may replace some results because of own purposes
(for example, to support gfx, rogue_km is replaced)
In this case, the rebuild may be impossible and not required.
To avoid the error, the signature file is created at the end of the build and
checked at the beginning - if file exists, re-build is not required.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>