### PR TITLE
Add zip-native to doma

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
+++ b/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
@@ -17,7 +17,7 @@ inherit xt_reconstruct
 # and tools: these are not needed for Android
 BASEDEPENDS = ""
 
-DEPENDS += "lz4-native bc-native python-pycrypto-native curl-native rsync-native bison-native coreutils-native unzip-native"
+DEPENDS += "lz4-native bc-native python-pycrypto-native curl-native rsync-native bison-native coreutils-native unzip-native zip-native"
 
 ANDROID_PRODUCT ?= "aosp_arm64"
 ANDROID_VARIANT ?= "eng"


### PR DESCRIPTION
The recipe zip-native is added to doma, reason is to fix the following build error
FAILED: /mnt/work/tmp/current-build-cache/xenvm-r8a7795/soong/.intermediates/external/guice/guice_munge_srcjar/gen/guice_munge.srcjar
bash: zip: command not found

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>