### PR TITLE
optee-os: Enable CFG_CORE_MBEDTLS_MPI

### DIFF
--- a/recipes-domd/domd-image-minimal/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -35,7 +35,7 @@ EXTRA_OEMAKE = "PLATFORM=rcar \
 	       CFLAGS64=--sysroot=${STAGING_DIR_HOST} \
 	       CFG_SYSTEM_PTA=y \
 	       CFG_ASN1_PARSER=y \
-	       CFG_CORE_MBEDTLS_MPI=n \
+	       CFG_CORE_MBEDTLS_MPI=y \
 	       "
 
 do_configure() {


### PR DESCRIPTION
Enable CFG_CORE_MBEDTLS_MPI since it is needed for
OPTEE OS 3.9

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>