### PR TITLE
doma: Add a support of zip, Android 11

### DIFF
--- a/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
+++ b/recipes-domu/domu-image-android/files/meta-xt-images-extra/recipes-extended/android/android.bb
@@ -17,7 +17,7 @@ inherit xt_reconstruct
 # and tools: these are not needed for Android
 BASEDEPENDS = ""
 
-DEPENDS += "lz4-native bc-native python-pycrypto-native curl-native rsync-native bison-native coreutils-native unzip-native"
+DEPENDS += "lz4-native bc-native python-pycrypto-native curl-native rsync-native bison-native coreutils-native unzip-native zip-native"
 
 ANDROID_PRODUCT ?= "aosp_arm64"
 ANDROID_VARIANT ?= "eng"


### PR DESCRIPTION
doma: Add a support of zip, Android 11

During the build, android build-script modify the jar file(s)
to remove unnecesary files.
For example
" Remove MungeTask.java, which is missing ant dependencies in Android.genrule "
to support it, zip has to be added.
Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>