### PR TITLE
Add Salvator-XS r8a7796 ES3.0+ with 8GiB (2 x 4 GiB) machine

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-m3-2x4g-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/salvator-xs-m3-2x4g-xt.conf
@@ -1,0 +1,14 @@
+#@TYPE: Machine
+#@NAME: Salvator-XS M3 ES3.0 8GB machine
+#@DESCRIPTION: Machine configuration for running xen domain on Salvator-X M3 ES3.0 8GB
+
+SOC_FAMILY = "r8a7796"
+
+XT_CANONICAL_MACHINE_NAME = "salvator-xs-2x4g"
+
+require conf/machine/include/rcar.inc
+
+# H3 u-boot configure
+UBOOT_MACHINE = "r8a7796_salvator-xs-2x4g_defconfig"
+
+MACHINEOVERRIDES .= ":salvator:rcar:r8a7796-es3"


### PR DESCRIPTION
Add Renesas Salvator-XS 2nd version board based on r8a7796 ES3.0+
with 8GiB (2 x 4 GiB) machine.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>