### PR TITLE
xt_quirk: link devel sources instead copy

### DIFF
--- a/classes/xt_quirks.bbclass
+++ b/classes/xt_quirks.bbclass
@@ -83,3 +83,6 @@ python do_xt_config_reconstruct() {
     with open(conf_file, "a") as f:
         f.write("require" + " " + "build-versions.inc" + "\n")
 }
+
+do_configure[nostamp] = "1"
+do_compile[nostamp] = "1"


### PR DESCRIPTION
Use symbol link for development sources instead of copy

PR should be merged with https://github.com/xen-troops/meta-xt-prod-devel/pull/327

@andr2000
@lorc

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>