### PR TITLE
gles-user-module: Install user files to localstatedir

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
@@ -53,6 +53,8 @@ EXTRA_OEMAKE += "KERNELDIR=${STAGING_KERNEL_BUILDDIR}"
 EXTRA_OEMAKE += "METAG_INST_ROOT=${S}/metag/2.8"
 EXTRA_OEMAKE += "LLVM_BUILD_DIR=${STAGING_LIBDIR}/llvm_build_dir"
 EXTRA_OEMAKE += "PVRSRV_VZ_NUM_OSID=${XT_PVR_NUM_OSID}"
+EXTRA_OEMAKE += "BIN_DESTDIR=${bindir}"
+EXTRA_OEMAKE += "SHARE_DESTDIR=${datadir}"
 
 RDEPENDS_${PN} = " \
     kernel-module-gles \
@@ -117,8 +119,8 @@ FILES_${PN} = " \
     /lib/firmware/rgx.fw* \
     ${localedir}/bin/* \
     ${exec_prefix}/bin/* \
-    ${exec_prefix}/local/share/* \
-    ${exec_prefix}/local/bin/* \
+    ${datadir}/* \
+    ${bindir}/* \
 "
 
 FILES_${PN}-dev = " \
@@ -127,7 +129,7 @@ FILES_${PN}-dev = " \
 "
 
 FILES_${PN}-debug = " \
-    ${exec_prefix}/local/bin/dlcsrv_REL \
+    ${bindir}/dlcsrv_REL \
 "
 
 # Skip debug strip of do_populate_sysroot()

--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/rcar-proprietary-graphic.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/rcar-proprietary-graphic.inc
@@ -45,8 +45,8 @@ do_install() {
     # Install pre-builded binaries
     install -d ${D}/${libdir}
     install -m 755 ${S}/${libdir}/*.so ${D}/${libdir}/
-    install -d ${D}/${exec_prefix}/local/bin
-    install -m 755 ${S}/${exec_prefix}/local/bin/dlcsrv_REL ${D}/${exec_prefix}/local/bin/dlcsrv_REL
+    install -d ${D}/${bindir}
+    install -m 755 ${S}/${bindir}/dlcsrv_REL ${D}/${bindir}/dlcsrv_REL
     install -d ${D}/lib/firmware
     install -m 644 ${S}/lib/firmware/* ${D}/lib/firmware/
     # Install pkgconfig
@@ -84,7 +84,7 @@ FILES_${PN} = " \
     ${libdir}/* \
     /lib/modules/${KERNEL_VERSION}/extra/* \
     /lib/firmware/rgx.fw* \
-    /usr/local/bin/* \
+    ${bindir}/* \
     ${exec_prefix}/bin/* \
     ${includedir}/* \
     ${libdir}/pkgconfig/* \


### PR DESCRIPTION
If not instructed gles-user-module tries to install user files into
/usr/local which is wrong in case of AGL which installs such files into
/var/local.
Fix this by properly configuring gles-user-module with this respect.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>
Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>