### PR TITLE
Extend some layer's compatibility to rocko

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/layer.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/layer.conf
@@ -12,4 +12,4 @@ BBFILE_PRIORITY_rcar-gen3-xen = "6"
 PREFERRED_PROVIDER_iasl = "iasl-native"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
 
-LAYERSERIES_COMPAT_rcar-gen3-xen = "sumo thud zeus dunfell"
+LAYERSERIES_COMPAT_rcar-gen3-xen = "rocko sumo thud zeus dunfell"

--- a/recipes-domx/meta-xt-images-domx/conf/layer.conf
+++ b/recipes-domx/meta-xt-images-domx/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "meta-xt-images-domx"
 BBFILE_PATTERN_meta-xt-images-domx = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-images-domx = "6"
 
-LAYERSERIES_COMPAT_meta-xt-images-domx = "sumo thud zeus dunfell"
+LAYERSERIES_COMPAT_meta-xt-images-domx = "rocko sumo thud zeus dunfell"

--- a/recipes-domx/meta-xt-images-vgpu/conf/layer.conf
+++ b/recipes-domx/meta-xt-images-vgpu/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_COLLECTIONS += "meta-xt-images-vgpu"
 BBFILE_PATTERN_meta-xt-images-vgpu = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-xt-images-vgpu = "6"
 
-LAYERSERIES_COMPAT_meta-xt-images-vgpu = "sumo thud zeus dunfell"
+LAYERSERIES_COMPAT_meta-xt-images-vgpu = "rocko sumo thud zeus dunfell"


### PR DESCRIPTION
Some of the layers can still be used with rocko release, so do not limit
such products. Set rocko to be compatible in the following products:
- meta-xt-images-rcar-gen3
- meta-xt-images-domx
- meta-xt-images-vgpu

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>