### PR TITLE
Cetibox: set UBOOT_MACHINE = "r8a7795_cetibox_h3ulcb_defconfig"

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-cb-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-cb-xt.conf
@@ -1,9 +1,12 @@
 #@TYPE: Machine
 #@NAME: H3ULCB ES2.0 Cetibox machine
 #@DESCRIPTION: Machine configuration for running xen domain on H3ULCB ES2.0 Cetibox
+SOC_FAMILY = "r8a7795"
 
-require h3ulcb-xt.conf
+require conf/machine/include/rcar.inc
+
+UBOOT_MACHINE = "r8a7795_cetibox_h3ulcb_defconfig"
+
+MACHINEOVERRIDES .= ":ulcb:rcar:r8a7795-es2:cetibox"
 
 XT_CANONICAL_MACHINE_NAME = "h3ulcb-cb"
-
-MACHINEOVERRIDES .= ":cetibox"


### PR DESCRIPTION
h3ulcb-cb-xt.conf included the 'h3ulcb-xt.conf ', it was the reason
of the wrong defconfig usage.
Include is removed.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>