### PR TITLE
DomD, DomU: Remove bison, python-clang, intent from the hosttools

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-devtools/python/python-clang_5.0.post2.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-devtools/python/python-clang_5.0.post2.bb
@@ -1,0 +1,21 @@
+inherit setuptools
+SUMMARY = "Clang Python Bindings."
+
+DESCRIPTION = "This is the python bindings subdir of llvm clang repository. \
+               https://github.com/llvm-mirror/clang/tree/master/bindings/python \
+               This is a non-official fork. Mainly for Pypi packaging purposes. \
+               The pypi package is not official either."
+
+HOMEPAGE = "http://clang.llvm.org/"
+SECTION = "devel/python"
+LICENSE = "NCSA"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=4d988f5f6d4fbc155861011db6de9182"
+
+SRC_URI[md5sum] = "7161729f47c84c629fdd11eed693ac04"
+SRC_URI[sha256sum] = "485985daf0a301e01b924db49ecb3e8b05ea40d6ab404f1778b8bfd5e4c89391"
+
+inherit native pypi
+
+PYPI_PACKAGE = "clang-5"
+RDEPENDS = "python-native"
+BBCLASSEXTEND = "native"

--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
@@ -10,6 +10,10 @@ DEPENDS = " \
     virtual/kernel \
     wayland-kms \
     llvmpvr \
+    indent-native \
+    bison-native \
+    python-clang-native \
+    python-native \
 "
 
 PN = "gles-user-module"


### PR DESCRIPTION
gles-user-module depends on 'python-native' to use the python instance,
also, the gles-user-module depends on bison-native, python-clang-native, indent-native to remove the dependency
on the host bison and python-clang.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>
Reviewed-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>
Reviewed-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>