### PR TITLE
[DO NOT MERGE][WORKAROUND] gfx: Use different paths for proprietary graphics

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
@@ -119,8 +119,8 @@ FILES_${PN} = " \
     /lib/firmware/rgx.fw* \
     ${localedir}/bin/* \
     ${exec_prefix}/bin/* \
-    ${datadir}/* \
-    ${bindir}/* \
+    ${@bb.utils.contains('PREFERRED_PROVIDER_gles-user-module', 'rcar-proprietary-graphic', '${exec_prefix}/local/share/* ', '${datadir}/* ', d) } \
+    ${@bb.utils.contains('PREFERRED_PROVIDER_gles-user-module', 'rcar-proprietary-graphic', '${exec_prefix}/local/bin/* ',   '${bindir}/* ',d ) } \
 "
 
 FILES_${PN}-dev = " \
@@ -129,7 +129,7 @@ FILES_${PN}-dev = " \
 "
 
 FILES_${PN}-debug = " \
-    ${bindir}/dlcsrv_REL \
+    ${@bb.utils.contains('PREFERRED_PROVIDER_gles-user-module', 'rcar-proprietary-graphic', '${exec_prefix}/local/bin/dlcsrv_REL ', '${bindir}/dlcsrv_REL ',d ) } \
 "
 
 # Skip debug strip of do_populate_sysroot()

--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/rcar-proprietary-graphic.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/rcar-proprietary-graphic.inc
@@ -45,8 +45,13 @@ do_install() {
     # Install pre-builded binaries
     install -d ${D}/${libdir}
     install -m 755 ${S}/${libdir}/*.so ${D}/${libdir}/
-    install -d ${D}/${bindir}
-    install -m 755 ${S}/${bindir}/dlcsrv_REL ${D}/${bindir}/dlcsrv_REL
+    if [ ${@bb.utils.contains('PREFERRED_PROVIDER_gles-user-module', 'rcar-proprietary-graphic', 'true', 'false', d)} ] ; then
+        install -d ${D}/${exec_prefix}/local/bin
+        install -m 755 ${S}/${exec_prefix}/local/bin/dlcsrv_REL ${D}/${exec_prefix}/local/bin/dlcsrv_REL
+    else
+        install -d ${D}/${bindir}
+        install -m 755 ${S}/${bindir}/dlcsrv_REL ${D}/${bindir}/dlcsrv_REL
+    fi
     install -d ${D}/lib/firmware
     install -m 644 ${S}/lib/firmware/* ${D}/lib/firmware/
     # Install pkgconfig
@@ -84,7 +89,7 @@ FILES_${PN} = " \
     ${libdir}/* \
     /lib/modules/${KERNEL_VERSION}/extra/* \
     /lib/firmware/rgx.fw* \
-    ${bindir}/* \
+    ${@bb.utils.contains('PREFERRED_PROVIDER_gles-user-module', 'rcar-proprietary-graphic', '/usr/local/bin/* ', '${bindir}/* ', d) } \
     ${exec_prefix}/bin/* \
     ${includedir}/* \
     ${libdir}/pkgconfig/* \


### PR DESCRIPTION
Prebuilt proprietary graphics is using hardcoded paths
that differs from cannonical.
So we need to use different paths for two cases:
- proprietary graphics is used
- canonical paths are used (AGL, for example)

Fixup: acfb476
"gles-user-module: Install user files to canonical locations"