### PR TITLE
domx: Reuse universal sstate across domains

### DIFF
--- a/recipes-domx/meta-xt-images-domx/classes/sstate.bbclass
+++ b/recipes-domx/meta-xt-images-domx/classes/sstate.bbclass
@@ -1,0 +1,8 @@
+
+inherit ${TOPDIR}/../poky/meta/classes/sstate.bbclass
+
+python () {
+    if bb.data.inherits_class('native', d) or bb.data.inherits_class('crosssdk', d) or bb.data.inherits_class('cross', d):
+        d.setVar('SSTATE_EXTRAPATH', "../${NATIVELSBSTRING}/")
+        d.setVar('SSTATE_EXTRAPATHWILDCARD', "../${NATIVELSBSTRING}/")
+}


### PR DESCRIPTION
The native tools and crosssdk packages are built separately for every
domain. Reuse of sstate increases the first build time because those
projects build once only.
There could be a more proper solution, but the variable for path prefix
SSTATE_EXTRAPATH is hardcoded in poky and the is no way to overwrite it
in user recipes.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>

@lorc 
@andr2000 
@arminn