### PR TITLE
xt_quirk: link devel sources instead copy

### DIFF
--- a/classes/xt_quirks.bbclass
+++ b/classes/xt_quirks.bbclass
@@ -83,3 +83,6 @@ python do_xt_config_reconstruct() {
     with open(conf_file, "a") as f:
         f.write("require" + " " + "build-versions.inc" + "\n")
 }
+
+do_configure[nostamp] = "1"
+do_compile[nostamp] = "1"


### PR DESCRIPTION

XT_QUIRK_UNPACK_SRC_URI is used to copy additional files into the inner
(domain's) build. For development purposes for every change in the
repository, it is necessary to move files into internal assemblies.

Use symbol links instead of copying to use recipe source code directly
from the original repository.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>
Reviewed-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
