### PR TITLE
[for REL-v6.0] Add support for Aos box (H3ULCB ES3.0 8GB)

### DIFF
--- a/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-4x2g-ab-xt.conf
+++ b/machine/meta-xt-images-rcar-gen3/conf/machine/h3ulcb-4x2g-ab-xt.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: H3ULCB ES3.0 8GB Aos box machine
+#@DESCRIPTION: Machine configuration for running xen domain on H3ULCB ES3.0 8GB Aos box 
+
+require h3ulcb-4x2g-xt.conf
+
+XT_CANONICAL_MACHINE_NAME = "h3ulcb-4x2g-ab"
+
+MACHINEOVERRIDES .= ":aosbox"

--- a/recipes-domx/meta-xt-images-domx/recipes-security/optee/optee-os_git.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-security/optee/optee-os_git.bb
@@ -27,6 +27,7 @@ OPTEEFLAVOR_salvator-xs-h3-xt = "salvator_h3"
 OPTEEFLAVOR_salvator-x-h3-4x2g-xt = "salvator_h3_4x2g"
 OPTEEFLAVOR_salvator-xs-h3-4x2g-xt = "salvator_h3_4x2g"
 OPTEEFLAVOR_h3ulcb-4x2g-xt = "salvator_h3_4x2g"
+OPTEEFLAVOR_h3ulcb-4x2g-ab-xt = "salvator_h3_4x2g"
 OPTEEFLAVOR_h3ulcb-4x2g-kf-xt = "salvator_h3_4x2g"
 OPTEEFLAVOR_salvator-xs-m3-2x4g-xt = "salvator_m3_2x4g"
 


### PR DESCRIPTION
Add support for H3ULCB AB ES3.0 8GB machine(CCPF Starter kit).
The configuration is based on R-Car Starter Kit H3ULCB 4x2g for now.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>
Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>

Should be merged with https://github.com/xen-troops/meta-xt-prod-devel/pull/348