### PR TITLE
gles-user-module: remove the 'non-conditioned' dependency on wayland-kms

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-graphics/gles-module/gles-user-module.inc
@@ -8,7 +8,6 @@ DEPENDS = " \
     wayland-native \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'libgbm wayland-kms', '', d)} \
     virtual/kernel \
-    wayland-kms \
     llvmpvr \
     indent-native \
     bison-native \


### PR DESCRIPTION
wayland-kms must be included in the build only if DISTRO_FEATURE contains 'wayland'

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>