### PR TITLE
URIs: replace git protocol at https one for the github sources.

### DIFF
--- a/recipes-domx/meta-xt-images-domx/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domx/meta-xt-images-domx/recipes-bsp/optee/optee-os_git.bbappend
@@ -1,7 +1,7 @@
 # Prevent installing optee-os binaries into the image rootfs
 ALLOW_EMPTY_${PN} = "1"
 
-SRC_URI = " git://github.com/xen-troops/optee_os.git"
+SRC_URI = " git://github.com/xen-troops/optee_os.git;protocol=https"
 PV = "git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"

--- a/recipes-domx/meta-xt-images-domx/recipes-graphics/wayland/wayland-ivi-extension_1.10.90.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-graphics/wayland/wayland-ivi-extension_1.10.90.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
 PR = "r1"
 SRCREV = "e232017e0906557f468823505a49e92d4c94591c"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
     "
 S = "${WORKDIR}/git"
 

--- a/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
@@ -16,7 +16,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 PVRKM_URL ?= "git://github.com:xen-troops/pvr_km.git"
 BRANCH ?= "master"
 
-SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${BRANCH}"
+SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${BRANCH};protocol=https"
 
 S = "${WORKDIR}/git"
 B = "${KBUILD_DIR}"


### PR DESCRIPTION
Use https instead of git because unauthenticated git protocol is disabled by github.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>