### PR TITLE
URIs: replace git protocol at https one for the github sources.

### DIFF
--- a/inc/agl.inc
+++ b/inc/agl.inc
@@ -29,7 +29,7 @@ BRANCH ?= "morty"
 SRC_URI_append = " \
     git://git.yoctoproject.org/meta-virtualization;destsuffix=repo/meta-virtualization;branch=${BRANCH} \
     git://git.yoctoproject.org/meta-selinux;destsuffix=repo/meta-selinux;branch=${BRANCH} \
-    git://github.com/kraj/meta-clang.git;destsuffix=repo/meta-clang;branch=${BRANCH} \
+    git://github.com/kraj/meta-clang.git;destsuffix=repo/meta-clang;branch=${BRANCH};protocol=https \
 "
 
 ################################################################################

--- a/recipes-domd/domd-image-minimal/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-minimal/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -1,7 +1,7 @@
 # Prevent installing optee-os binaries into the image rootfs
 ALLOW_EMPTY_${PN} = "1"
 
-SRC_URI = " git://github.com/xen-troops/optee_os.git"
+SRC_URI = " git://github.com/xen-troops/optee_os.git;protocol=https"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
 

--- a/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
+++ b/recipes-domd/domd-image-weston/files_rcar/meta-xt-images-extra/recipes-bsp/optee/optee-os_git.bbappend
@@ -1,7 +1,7 @@
 # Prevent installing optee-os binaries into the image rootfs
 ALLOW_EMPTY_${PN} = "1"
 
-SRC_URI = " git://github.com/xen-troops/optee_os.git"
+SRC_URI = " git://github.com/xen-troops/optee_os.git;protocol=https"
 PV = "git${SRCPV}"
 
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"

--- a/recipes-domx/meta-xt-images-domx/recipes-graphics/wayland/wayland-ivi-extension_1.10.90.bb
+++ b/recipes-domx/meta-xt-images-domx/recipes-graphics/wayland/wayland-ivi-extension_1.10.90.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1f1a56bb2dadf5f2be8eb342acf4ed79"
 
 PR = "r1"
 SRCREV = "e232017e0906557f468823505a49e92d4c94591c"
-SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=http \
+SRC_URI = "git://github.com/GENIVI/${BPN}.git;protocol=https \
     "
 S = "${WORKDIR}/git"
 

--- a/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
@@ -13,7 +13,7 @@ PR = "r1"
 COMPATIBLE_MACHINE = "(r8a7795|r8a7796|r8a77965)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-PVRKM_URL ?= "git://github.com:xen-troops/pvr_km.git"
+PVRKM_URL ?= "git://github.com:xen-troops/pvr_km.git;protocol=https"
 BRANCH ?= "master"
 
 SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${BRANCH}"


### PR DESCRIPTION
Use https instead of git because unauthenticated git protocol is disabled by github.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>