### PR TITLE
[REL-v7.0] gles: Do not force https for sources

### DIFF
--- a/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
+++ b/recipes-domx/meta-xt-images-vgpu/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
@@ -16,7 +16,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 PVRKM_URL ?= "git://github.com:xen-troops/pvr_km.git"
 BRANCH ?= "master"
 
-SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${BRANCH};protocol=https"
+SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${BRANCH}"
 
 S = "${WORKDIR}/git"
 B = "${KBUILD_DIR}"


### PR DESCRIPTION
We use proprietary repository for gles.
Switch to https protocol results in request for
user's login and password.
Such behaviour is not acceptable for fetch by script.

Fixes 704bfe28173f40c09aeef76dc01fc0fe91c08a47

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>